### PR TITLE
Fix installation scripts to extract from zip archive

### DIFF
--- a/install_vortex.bat
+++ b/install_vortex.bat
@@ -20,10 +20,9 @@ if not exist "%MC_DIR%\versions\vortex-loader-1.0.0-1.21.8" (
     echo Vortex directory already exists, will overwrite files.
 )
 
-REM Copy files
-echo Copying Vortex loader files...
-copy /Y "vortex-loader-1.0.0-1.21.8.jar" "%MC_DIR%\versions\vortex-loader-1.0.0-1.21.8&quot;
-copy /Y "vortex-loader-1.0.0-1.21.8.json" "%MC_DIR%\versions\vortex-loader-1.0.0-1.21.8&quot;
+REM Extract files
+echo Extracting Vortex loader files...
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& { Expand-Archive -Path 'rrrrrrrr.zip' -DestinationPath '%TEMP%\vortex_temp' -Force; Move-Item -Path '%TEMP%\vortex_temp\rrrrrrrr\*' -Destination '%MC_DIR%\versions\vortex-loader-1.0.0-1.21.8\'; Remove-Item -Path '%TEMP%\vortex_temp' -Recurse -Force }"
 
 echo.
 echo Installation complete!

--- a/install_vortex.ps1
+++ b/install_vortex.ps1
@@ -34,10 +34,12 @@ if (-not (Test-Path $VORTEX_DIR)) {
     Write-Host "Vortex directory already exists, will overwrite files." -ForegroundColor Yellow
 }
 
-# Copy files
-Write-Host "Copying Vortex loader files..." -ForegroundColor Green
-Copy-Item -Path "vortex-loader-1.0.0-1.21.8.jar" -Destination "$VORTEX_DIR&quot; -Force
-Copy-Item -Path "vortex-loader-1.0.0-1.21.8.json" -Destination "$VORTEX_DIR&quot; -Force
+# Extract files
+Write-Host "Extracting Vortex loader files..." -ForegroundColor Green
+$TEMP_DIR = Join-Path $env:TEMP "vortex_temp"
+Expand-Archive -Path "rrrrrrrr.zip" -DestinationPath $TEMP_DIR -Force
+Move-Item -Path "$TEMP_DIR\rrrrrrrr\*" -Destination $VORTEX_DIR -Force
+Remove-Item -Path $TEMP_DIR -Recurse -Force
 
 # Create ovmods directory if it doesn't exist
 if (-not (Test-Path "$MC_DIR\ovmods")) {

--- a/install_vortex.sh
+++ b/install_vortex.sh
@@ -25,10 +25,10 @@ fi
 echo "Creating Vortex loader directory..."
 mkdir -p "$MC_DIR/versions/vortex-loader-1.0.0-1.21.8"
 
-# Copy files
-echo "Copying Vortex loader files..."
-cp -f "vortex-loader-1.0.0-1.21.8.jar" "$MC_DIR/versions/vortex-loader-1.0.0-1.21.8/"
-cp -f "vortex-loader-1.0.0-1.21.8.json" "$MC_DIR/versions/vortex-loader-1.0.0-1.21.8/"
+# Extract files
+echo "Extracting Vortex loader files..."
+unzip -j rrrrrrrr.zip "rrrrrrrr/vortex-loader-1.0.0-1.21.8.jar" -d "$MC_DIR/versions/vortex-loader-1.0.0-1.21.8/"
+unzip -j rrrrrrrr.zip "rrrrrrrr/vortex-loader-1.0.0-1.21.8.json" -d "$MC_DIR/versions/vortex-loader-1.0.0-1.21.8/"
 
 echo
 echo "Installation complete!"


### PR DESCRIPTION
The installation scripts (`install_vortex.sh`, `install_vortex.bat`, and `install_vortex.ps1`) were previously trying to copy the Vortex loader files directly, but these files are distributed inside a zip archive (`rrrrrrrr.zip`).

This change modifies the scripts to extract the necessary files from the zip archive into the correct Minecraft versions directory.

- `install_vortex.sh` now uses `unzip`.
- `install_vortex.bat` now uses a PowerShell command to call `Expand-Archive`.
- `install_vortex.ps1` now uses `Expand-Archive` directly.